### PR TITLE
Patch out the reference to `ast.Str` in `kivy.lang.parser`

### DIFF
--- a/pythonforandroid/recipes/kivy/__init__.py
+++ b/pythonforandroid/recipes/kivy/__init__.py
@@ -32,7 +32,11 @@ class KivyRecipe(PyProjectRecipe):
     # sdl-gl-swapwindow-nogil.patch is needed to avoid a deadlock.
     # See: https://github.com/kivy/kivy/pull/8025
     # WARNING: Remove this patch when a new Kivy version is released.
-    patches = [("sdl-gl-swapwindow-nogil.patch", is_kivy_affected_by_deadlock_issue), "use_cython.patch"]
+    patches = [
+        ("sdl-gl-swapwindow-nogil.patch", is_kivy_affected_by_deadlock_issue),
+        "use_cython.patch",
+        "no-ast-str.patch"
+    ]
 
     @property
     def need_stl_shared(self):

--- a/pythonforandroid/recipes/kivy/no-ast-str.patch
+++ b/pythonforandroid/recipes/kivy/no-ast-str.patch
@@ -1,0 +1,16 @@
+diff -ur kivy-2.3.1b/kivy/lang/parser.py kivy-2.3.1/kivy/lang/parser.py
+--- kivy-2.3.1b/kivy/lang/parser.py	2025-10-19 13:04:51.542798827 +1300
++++ kivy-2.3.1/kivy/lang/parser.py	2025-10-19 13:05:16.007104601 +1300
+@@ -230,11 +230,7 @@
+ 
+         if isinstance(node, (ast.JoinedStr, ast.BoolOp)):
+             for n in node.values:
+-                if isinstance(n, ast.Str):
+-                    # NOTE: required for python3.6
+-                    yield from cls.get_names_from_expression(n.s)
+-                else:
+-                    yield from cls.get_names_from_expression(n.value)
++                yield from cls.get_names_from_expression(n.value)
+ 
+         if isinstance(node, ast.BinOp):
+             yield from cls.get_names_from_expression(node.right)


### PR DESCRIPTION
It broke Python 3.14, and I don't think Kivy even supports Python 3.6 anymore.